### PR TITLE
Updates to password generation for VMs

### DIFF
--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -36,7 +36,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
 
-> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed post deployment on the VMs to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
+> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
   
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 

--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -34,8 +34,10 @@ There are two options available to set up the prerequisites for this scenario.
 
 Option 1 - Click the link below to automatically create the necessary VMs with a vanilla build of docker. 
 
-    Note that this automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion. 
+  > Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
 
+  > Note: The passwords that are generated and stored in keyvault are deterministic and therefore should be changed to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a Proof of Concept only and not for production use.
+  
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 

--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -34,9 +34,9 @@ There are two options available to set up the prerequisites for this scenario.
 
 Option 1 - Click the link below to automatically create the necessary VMs with a vanilla build of docker. 
 
-  > Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
+> Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
 
-  > Note: The passwords that are generated and stored in keyvault are deterministic and therefore should be changed to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a Proof of Concept only and not for production use.
+> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed post deployment on the VMs to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
   
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -34,9 +34,9 @@ There are two options available to set up the prerequisites for this scenario.
 
 Option 1 - Click the link below to automatically create the necessary VMs with a vanilla build of docker. 
 
-  > Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
+> Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
 
-  > Note: The passwords that are generated and stored in keyvault are deterministic and therefore should be changed to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a Proof of Concept only and not for production use.
+> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed post deployment on the VMs to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -34,6 +34,10 @@ There are two options available to set up the prerequisites for this scenario.
 
 Option 1 - Click the link below to automatically create the necessary VMs with a vanilla build of docker. 
 
+  > Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
+
+  > Note: The passwords that are generated and stored in keyvault are deterministic and therefore should be changed to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a Proof of Concept only and not for production use.
+
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -36,7 +36,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
 
-> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed post deployment on the VMs to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
+> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 

--- a/aks/json/dockerhost.json
+++ b/aks/json/dockerhost.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.3.255.40792",
-      "templateHash": "6556817742032746960"
+      "templateHash": "11239803038205840081"
     }
   },
   "parameters": {
@@ -285,7 +285,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.3.255.40792",
-              "templateHash": "8137733279706470109"
+              "templateHash": "15811957911396920799"
             }
           },
           "parameters": {
@@ -306,7 +306,7 @@
             },
             "adminPassword": {
               "type": "secureString",
-              "defaultValue": "[format('{0}aA1!', uniqueString(resourceGroup().id))]"
+              "defaultValue": "[format('{0}aA1!', uniqueString(resourceGroup().id, parameters('vmname')))]"
             },
             "vmSize": {
               "type": "string",


### PR DESCRIPTION
This pull request includes the following : 

- An update to the underlying deployment JSON to create unique passwords for each VM. The uniquestring includes the VMname to achieve this.
- Updates to the notes in the markdown for each deployment to advise the user that the passwords are generated deterministically and therefore not intended for production use.
- Also changed the "note" appearance to be consistent with the format used for a markdown note rather than a code block. 