### PR TITLE
Add username to Keyvault, Add PIPs for Docker Hosts and NSG with Default SSH deny. Update documentation

### DIFF
--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -10,6 +10,9 @@ This architecture demonstrates VXLAN network overlay with multi-host docker swar
 
 Download Visio link here.
 
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshcrouch%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+
+> Please see notes from Docker Installation Option 1 for 'Deploy to Azure' usage.
 ## Documentation links
 
 1. [Install Docker on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
@@ -32,23 +35,37 @@ Download Visio link here.
 
 There are two options available to set up the prerequisites for this scenario.
 
-Option 1 - Click the link below to automatically create the necessary VMs with a vanilla build of docker. 
+### Option 1 - Automated Deployment
 
-> Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
+Click the 'Deploy to Azure' link above to automatically create the necessary Azure VMs with a vanilla build of docker on each host.
 
-> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
-  
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+<br /> 
 
+> Note: This automated deployment deploys Azure Bastion so you can connect to the VMs via the portal using Bastion. Alternatively the subnet hosting the VMs has an Network Security Group attached called "Allow-tunnel-traffic" with a rule called 'allow-ssh-inbound' which is set to Deny by default. If you need to temporarily allow SSH direct to the hosts, you can edit this rule and change the Source from 127.0.0.1 to your current public IP address (type "what is my ip address" into your favorite search engine to obtain this). Afterwards, set the rule from Deny to Allow and save.  
 
-Option 2 - Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.
+<br /> 
+
+> Note: The credentials for the VMs are stored in an Azure keyvault. The passwords are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and are not for production use. In order for the deployment to provision your signed-in user account access to the keyvault, you will need to provide your Azure Active Directory (AAD) signed-in user ObjectID. In order to retrieve this there are serveral methods. The Azure CLI and Azure Powershell methods are provided below
+
+Azure CLI
+``` 
+az ad signed-in-user show --query objectId -o tsv
+```
+
+Azure Powershell 
+```
+(Get-AzContext).Account.ExtendedProperties.HomeAccountId.Split('.')[0]
+```
+
+### Option 2 - Manual Deployment
+<br />
+Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.
 
 ```
 sudo apt-get update
 sudo apt-get install docker-ce docker-ce-cli containerd.io
 apt install bridge-utils
 ```
-
 ## Create a Docker Swarm Cluster
 
 List the default networks and initialize docker swarm cluster

--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -36,7 +36,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
 
-> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed post deployment on the VMs to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
+> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
   
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 

--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -10,7 +10,7 @@ This architecture demonstrates VXLAN network overlay with multi-host docker swar
 
 Download Visio link here.
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshcrouch%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 > Please see notes from Docker Installation Option 1 for 'Deploy to Azure' usage.
 ## Documentation links

--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -38,7 +38,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
   
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsdcscripts%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 
 Option 2 - Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.

--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -38,7 +38,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
   
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsdcscripts%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshcrouch%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 
 Option 2 - Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.

--- a/aks/README-docker-multihost.md
+++ b/aks/README-docker-multihost.md
@@ -38,7 +38,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
   
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshcrouch%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 
 Option 2 - Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -38,7 +38,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshcrouch%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 
 Option 2 - Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -38,7 +38,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsdcscripts%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshcrouch%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 
 Option 2 - Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -10,7 +10,7 @@ This architecture demonstrates single docker host and networking with the docker
 
 Download Visio link here.
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshcrouch%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 > Please see notes from Docker Installation Option 1 for 'Deploy to Azure' usage.
 ## Documentation links

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -38,7 +38,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsdcscripts%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 
 
 Option 2 - Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -10,6 +10,9 @@ This architecture demonstrates single docker host and networking with the docker
 
 Download Visio link here.
 
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshcrouch%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+
+> Please see notes from Docker Installation Option 1 for 'Deploy to Azure' usage.
 ## Documentation links
 
 1. [Install Docker on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
@@ -32,16 +35,31 @@ The above architecture diagram contains a few key components
 
 There are two options available to set up the prerequisites for this scenario.
 
-Option 1 - Click the link below to automatically create the necessary VMs with a vanilla build of docker. 
+### Option 1 - Automated Deployment
 
-> Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
+Click the 'Deploy to Azure' link above to automatically create the necessary Azure VMs with a vanilla build of docker on each host.
 
-> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
+<br /> 
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
+> Note: This automated deployment deploys Azure Bastion so you can connect to the VMs via the portal using Bastion. Alternatively the subnet hosting the VMs has an Network Security Group attached called "Allow-tunnel-traffic" with a rule called 'allow-ssh-inbound' which is set to Deny by default. If you need to temporarily allow SSH direct to the hosts, you can edit this rule and change the Source from 127.0.0.1 to your current public IP address (type "what is my ip address" into your favorite search engine to obtain this). Afterwards, set the rule from Deny to Allow and save.  
 
+<br /> 
 
-Option 2 - Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.
+> Note: The credentials for the VMs are stored in an Azure keyvault. The passwords are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and are not for production use. In order for the deployment to provision your signed-in user account access to the keyvault, you will need to provide your Azure Active Directory (AAD) signed-in user ObjectID. In order to retrieve this there are serveral methods. The Azure CLI and Azure Powershell methods are provided below
+
+Azure CLI
+``` 
+az ad signed-in-user show --query objectId -o tsv
+```
+
+Azure Powershell 
+```
+(Get-AzContext).Account.ExtendedProperties.HomeAccountId.Split('.')[0]
+```
+
+### Option 2 - Manual Deployment
+<br />
+Manually Create Ubuntu linux VMs (docker-host-1 and docker-host-2) in Azure subnet and install docker.
 
 ```
 sudo apt-get update

--- a/aks/README-docker-singlehost.md
+++ b/aks/README-docker-singlehost.md
@@ -36,7 +36,7 @@ Option 1 - Click the link below to automatically create the necessary VMs with a
 
 > Note: This automated deployment will also deploy Azure Bastion, so you can connect to the VMs via the portal using Bastion.
 
-> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed post deployment on the VMs to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
+> Note: The passwords for the VMs are stored in a keyvault. They are generated deterministically and therefore should be changed on the VMs post deployment, to maximise security. They are auto generated in this way for convenience and are intended to support this environment as a 'Proof of Concept' only and not for production use.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnehalineogi%2Fazure-cross-solution-network-architectures%2Fmain%2Faks%2Fjson%2Fdockerhost.json)
 

--- a/aks/json/dockerhost.json
+++ b/aks/json/dockerhost.json
@@ -69,7 +69,7 @@
     },
     "githubPath": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/sdcscripts/azure-cross-solution-network-architectures/main/aks/scripts/",
+      "defaultValue": "https://raw.githubusercontent.com/shcrouch/azure-cross-solution-network-architectures/main/aks/scripts/",
       "minLength": 10,
       "metadata": {
         "description": "Set the path to the github directory that has the custom script extension scripts"

--- a/aks/json/dockerhost.json
+++ b/aks/json/dockerhost.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.3.255.40792",
-      "templateHash": "5534480427331774639"
+      "templateHash": "6319430558605405580"
     }
   },
   "parameters": {
@@ -69,7 +69,7 @@
     },
     "githubPath": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/nehalineogi/azure-cross-solution-network-architectures/main/aks/scripts/",
+      "defaultValue": "https://raw.githubusercontent.com/shcrouch/azure-cross-solution-network-architectures/main/aks/scripts/",
       "minLength": 10,
       "metadata": {
         "description": "Set the path to the github directory that has the custom script extension scripts"
@@ -264,7 +264,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.3.255.40792",
-              "templateHash": "15811957911396920799"
+              "templateHash": "15511934471688168387"
             }
           },
           "parameters": {
@@ -299,14 +299,31 @@
               "metadata": {
                 "description": "location for all resources"
               }
+            },
+            "publicIPAddressNameSuffix": {
+              "type": "string",
+              "defaultValue": "pip"
             }
           },
           "functions": [],
           "variables": {
+            "dnsLabelPrefix": "[format('dns-{0}-{1}', uniqueString(resourceGroup().id, parameters('vmname')), parameters('publicIPAddressNameSuffix'))]",
             "storageAccountName": "[format('{0}{1}sa', uniqueString(resourceGroup().id), parameters('vmname'))]",
             "nicName": "[format('{0}myVMNic', parameters('vmname'))]"
           },
           "resources": [
+            {
+              "type": "Microsoft.Network/publicIPAddresses",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}-{1}', variables('nicName'), parameters('publicIPAddressNameSuffix'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "publicIPAllocationMethod": "Static",
+                "dnsSettings": {
+                  "domainNameLabel": "[variables('dnsLabelPrefix')]"
+                }
+              }
+            },
             {
               "type": "Microsoft.Storage/storageAccounts",
               "apiVersion": "2019-06-01",
@@ -328,13 +345,19 @@
                     "name": "ipconfig1",
                     "properties": {
                       "privateIPAllocationMethod": "Dynamic",
+                      "publicIPAddress": {
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-{1}', variables('nicName'), parameters('publicIPAddressNameSuffix')))]"
+                      },
                       "subnet": {
                         "id": "[parameters('subnet1ref')]"
                       }
                     }
                   }
                 ]
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-{1}', variables('nicName'), parameters('publicIPAddressNameSuffix')))]"
+              ]
             },
             {
               "type": "Microsoft.Compute/virtualMachines",
@@ -387,6 +410,18 @@
               "properties": {
                 "contentType": "securestring",
                 "value": "[parameters('adminPassword')]",
+                "attributes": {
+                  "enabled": true
+                }
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2019-09-01",
+              "name": "[format('{0}/{1}-admin-username', parameters('keyvault_name'), parameters('vmname'))]",
+              "properties": {
+                "contentType": "string",
+                "value": "[parameters('adminusername')]",
                 "attributes": {
                   "enabled": true
                 }
@@ -463,7 +498,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.3.255.40792",
-              "templateHash": "17886237105965997439"
+              "templateHash": "3077647611656484306"
             }
           },
           "parameters": {
@@ -528,14 +563,167 @@
               "type": "string",
               "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))).subnets[1].name]"
             },
+            "subnet1addressPrefix": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))).subnets[0].properties.addressPrefix]"
+            },
             "vnid": {
               "type": "string",
               "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+            },
+            "vnName": {
+              "type": "string",
+              "value": "[parameters('virtualNetworkName')]"
             }
           }
         }
       },
       "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('ResourceGroupName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "hubNSG",
+      "resourceGroup": "[parameters('ResourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "destinationAddressPrefix": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'dockernetwork'), '2019-10-01').outputs.subnet1addressPrefix.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.3.255.40792",
+              "templateHash": "779060282370331211"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string"
+            },
+            "destinationAddressPrefix": {
+              "type": "string"
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2020-06-01",
+              "name": "Allow-tunnel-traffic",
+              "location": "[parameters('location')]",
+              "properties": {
+                "securityRules": [
+                  {
+                    "name": "allow-ssh-inbound",
+                    "properties": {
+                      "priority": 1000,
+                      "access": "Deny",
+                      "direction": "Inbound",
+                      "destinationPortRange": "22",
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "127.0.0.1",
+                      "destinationAddressPrefix": "[parameters('destinationAddressPrefix')]"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "outputs": {
+            "nsgId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', 'Allow-tunnel-traffic')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'dockernetwork')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('ResourceGroupName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "onpremNsgAttachment",
+      "resourceGroup": "[parameters('ResourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "nsgId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'hubNSG'), '2019-10-01').outputs.nsgId.value]"
+          },
+          "subnetAddressPrefix": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'dockernetwork'), '2019-10-01').outputs.subnet1addressPrefix.value]"
+          },
+          "subnetName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'dockernetwork'), '2019-10-01').outputs.subnet1name.value]"
+          },
+          "vnetName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'dockernetwork'), '2019-10-01').outputs.vnName.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.3.255.40792",
+              "templateHash": "16856926705061277472"
+            }
+          },
+          "parameters": {
+            "vnetName": {
+              "type": "string"
+            },
+            "subnetName": {
+              "type": "string"
+            },
+            "subnetAddressPrefix": {
+              "type": "string"
+            },
+            "nsgId": {
+              "type": "string"
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/virtualNetworks/subnets",
+              "apiVersion": "2020-07-01",
+              "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnetName'))]",
+              "properties": {
+                "addressPrefix": "[parameters('subnetAddressPrefix')]",
+                "networkSecurityGroup": {
+                  "id": "[parameters('nsgId')]"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'hubNSG')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'dockernetwork')]",
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('ResourceGroupName'))]"
       ]
     },

--- a/aks/json/dockerhost.json
+++ b/aks/json/dockerhost.json
@@ -69,7 +69,7 @@
     },
     "githubPath": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/shcrouch/azure-cross-solution-network-architectures/main/aks/scripts/",
+      "defaultValue": "https://raw.githubusercontent.com/nehalineogi/azure-cross-solution-network-architectures/main/aks/scripts/",
       "minLength": 10,
       "metadata": {
         "description": "Set the path to the github directory that has the custom script extension scripts"

--- a/aks/json/dockerhost.json
+++ b/aks/json/dockerhost.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.3.255.40792",
-      "templateHash": "11239803038205840081"
+      "templateHash": "5534480427331774639"
     }
   },
   "parameters": {
@@ -17,15 +17,6 @@
       },
       "maxLength": 36,
       "minLength": 36
-    },
-    "Location": {
-      "type": "string",
-      "defaultValue": "UK South",
-      "maxLength": 20,
-      "minLength": 3,
-      "metadata": {
-        "description": "Set the location for the resource group and all resources"
-      }
     },
     "ResourceGroupName": {
       "type": "string",
@@ -69,13 +60,6 @@
         "description": "Name of the vnet"
       }
     },
-    "VnetAddressPrefix": {
-      "type": "string",
-      "defaultValue": "172.16.0.0/16",
-      "metadata": {
-        "description": "Set the address space for the VNet"
-      }
-    },
     "Subnet1Name": {
       "type": "string",
       "defaultValue": "dockersubnet",
@@ -83,17 +67,9 @@
         "description": "Set the name for the docker subnet"
       }
     },
-    "Subnet1Prefix": {
-      "type": "string",
-      "defaultValue": "172.16.24.0/24",
-      "minLength": 9,
-      "metadata": {
-        "description": "Set the subnet range for subnet1"
-      }
-    },
     "githubPath": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/nehalineogi/azure-cross-solution-network-architectures/main/aks/scripts/",
+      "defaultValue": "https://raw.githubusercontent.com/sdcscripts/azure-cross-solution-network-architectures/main/aks/scripts/",
       "minLength": 10,
       "metadata": {
         "description": "Set the path to the github directory that has the custom script extension scripts"
@@ -111,15 +87,18 @@
   },
   "functions": [],
   "variables": {
-    "bastionNetworkName": "AzureBastionSubnet",
-    "bastionSubnet": "172.16.1.0/24"
+    "location": "[deployment().location]",
+    "VnetAddressPrefix": "172.16.0.0/16",
+    "Subnet1Prefix": "172.16.24.0/24",
+    "bastionSubnet": "172.16.1.0/24",
+    "bastionNetworkName": "AzureBastionSubnet"
   },
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
       "apiVersion": "2020-10-01",
       "name": "[parameters('ResourceGroupName')]",
-      "location": "[parameters('Location')]"
+      "location": "[variables('location')]"
     },
     {
       "type": "Microsoft.Resources/deployments",
@@ -456,16 +435,16 @@
         "mode": "Incremental",
         "parameters": {
           "addressPrefix": {
-            "value": "[parameters('VnetAddressPrefix')]"
+            "value": "[variables('VnetAddressPrefix')]"
           },
           "location": {
-            "value": "[parameters('Location')]"
+            "value": "[variables('location')]"
           },
           "subnet1Name": {
             "value": "[parameters('Subnet1Name')]"
           },
           "subnet1Prefix": {
-            "value": "[parameters('Subnet1Prefix')]"
+            "value": "[variables('Subnet1Prefix')]"
           },
           "bastionNetworkName": {
             "value": "[variables('bastionNetworkName')]"
@@ -575,7 +554,7 @@
             "value": "bastion"
           },
           "location": {
-            "value": "[parameters('Location')]"
+            "value": "[variables('location')]"
           },
           "subnetRef": {
             "value": "[format('{0}/subnets/{1}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'dockernetwork'), '2019-10-01').outputs.vnid.value, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'dockernetwork'), '2019-10-01').outputs.bastionSubnetName.value)]"


### PR DESCRIPTION
This Pull Request has the following: 

- Add username for hosts to KV 
- Add Public IPs to both hosts
- Add NSG with default deny rule (quick ability to set to Allow with user public IP if required)
- Updates Markdown files to place Deploy to Azure button at top, with extra instructions for obtaining user's ObjectID and informing user of all credentials sent to Keyvault. 
- Removed ability for user to change network ranges in use for deployment (to avoid clash with bastion or other subnets and to ensure it matches the architectural diagram)